### PR TITLE
fix helm resources names

### DIFF
--- a/src/v2/schema/application-helper-util.js
+++ b/src/v2/schema/application-helper-util.js
@@ -186,17 +186,18 @@ export const createGenericPackageObject = (
 
 export const removeReleaseGeneratedSuffix = (name) => name.replace(/-[0-9a-zA-Z]{4,5}$/, '');
 
-// remove the release name from the deployable name
-export const removeHelmReleaseName = (name, releaseName) => {
-  const trimmedReleaseName = _.trimEnd(releaseName, '-');
-  let result = _.replace(name, `${trimmedReleaseName}-`, '');
-  result = _.replace(result, `${trimmedReleaseName}`, '');
-
-  // resource name only contains release name, return without the generated suffix
-  if (result.length === 0) {
+// use the package name is name is set using alias
+export const removeHelmReleaseName = (name, releaseName, packageName, aliasName) => {
+  if (!aliasName) {
+    // if no alias name set, the resource name ends with a chart hash, remove that
     return removeReleaseGeneratedSuffix(name);
   }
-  return result;
+
+  if (packageName && aliasName && `${name}-` === releaseName && name === aliasName) {
+    return packageName; // if name matches alias use package name instead
+  }
+
+  return name;
 };
 
 // add cluster node to RHCAM application

--- a/src/v2/schema/applicationHelper.js
+++ b/src/v2/schema/applicationHelper.js
@@ -179,6 +179,8 @@ export const getSubscriptionPackageInfo = (topoAnnotation, subscriptionName, app
   const deployablesList = [];
 
   const deployables = _.split(topoAnnotation, ',');
+  const packageName = _.get(_.get(subscription, 'spec.packageOverrides', [{}])[0], 'packageName');
+  const aliasName = _.get(_.get(subscription, 'spec.packageOverrides', [{}])[0], 'packageAlias');
 
   deployables.forEach((deployableInfo) => {
     const deployableData = _.split(deployableInfo, '/');
@@ -194,7 +196,7 @@ export const getSubscriptionPackageInfo = (topoAnnotation, subscriptionName, app
       // process only helm charts and hooks
       if (deployableData[0] === 'helmchart' || isHook) {
         if (!isHook) {
-          dName = removeHelmReleaseName(deployableData[4], deployableData[1]);
+          dName = removeHelmReleaseName(deployableData[4], deployableData[1], packageName, aliasName);
           namespace = deployableData[3].length === 0 ? appNamespace : deployableData[3];
           deployableName = `${subscriptionName}-${dName}-${dName}-${deployableTypeLower}`;
         }

--- a/src/v2/schema/applicationHelper.test.js
+++ b/src/v2/schema/applicationHelper.test.js
@@ -1390,6 +1390,18 @@ describe('removeHelmReleaseName test resource with only release name as the name
   });
 });
 
+describe('removeHelmReleaseName test with package alias not matching name', () => {
+  it('returns package name when resource name matches alias', () => {
+    expect(removeHelmReleaseName('apache-alias-name', 'apache-alias-name-', 'apache', 'apache-alias-name')).toEqual('apache');
+  });
+});
+
+describe('removeHelmReleaseName test with package alias matching name', () => {
+  it('removeHelmReleaseName returns name when resource name does not match alias', () => {
+    expect(removeHelmReleaseName('redis-master', 'my-alias-', 'redis', 'my-alias')).toEqual('redis-master');
+  });
+});
+
 describe('getLocalClusterElement cluster element exists', () => {
   it('should get the local cluster element', () => {
     const createdClusterElements = new Set(['member--clusters--cluster1, cluster2, local-cluster']);


### PR DESCRIPTION
**Related Issue:** https://github.com/open-cluster-management/backlog/issues/9666

**Description of Changes**
Update helm chart resource names when a helm package alias is used
In this case the resource name matches the alias name; we want to use the package name instead so that the deployed
resources are matched with the deployable using the app.kubernetes.io/instance value

- [x] I wrote test cases to cover new code
