### PR TITLE
fix helm resources names 2.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/nodejs-12:1
+FROM registry.access.redhat.com/ubi8/nodejs-14:1
 USER root
 RUN yum -y remove nodejs-nodemon
 RUN yum -y update

--- a/README.md
+++ b/README.md
@@ -63,3 +63,4 @@
    ```
    open https://localhost:4000/hcmuiapi/graphql
    ```
+

--- a/src/v2/models/generic.js
+++ b/src/v2/models/generic.js
@@ -456,7 +456,12 @@ export default class GenericModel extends KubeModel {
   }) {
     let computedResource;
     if (!resource) {
-      computedResource = (await this.getResourceInfo({ apiVersion: `${apiGroup}/${version}`, kind }))[1].name;
+      computedResource = (await this.getResourceInfo({
+        apiVersion: (apiGroup === '*' || apiGroup === '')
+          ? version
+          : `${apiGroup}/${version}`,
+        kind,
+      }))[1].name;
     }
     const body = {
       apiVersion: authApiVersion,

--- a/src/v2/schema/applicationHelper.test.js
+++ b/src/v2/schema/applicationHelper.test.js
@@ -1387,6 +1387,18 @@ describe('removeHelmReleaseName test resource with only release name as the name
   });
 });
 
+describe('removeHelmReleaseName test with package alias not matching name', () => {
+  it('returns package name when resource name matches alias', () => {
+    expect(removeHelmReleaseName('apache-alias-name', 'apache-alias-name-', 'apache', 'apache-alias-name')).toEqual('apache');
+  });
+});
+
+describe('removeHelmReleaseName test with package alias matching name', () => {
+  it('removeHelmReleaseName returns name when resource name does not match alias', () => {
+    expect(removeHelmReleaseName('redis-master', 'my-alias-', 'redis', 'my-alias')).toEqual('redis-master');
+  });
+});
+
 describe('getLocalClusterElement cluster element exists', () => {
   it('should get the local cluster element', () => {
     const createdClusterElements = new Set(['member--clusters--cluster1, cluster2, local-cluster']);


### PR DESCRIPTION
**Related Issue:** https://github.com/open-cluster-management/backlog/issues/9666

**Description of Changes**
Update helm chart resource names when a helm package alias is used
In this case the resource name matches the alias name; we want to use the package name instead so that the deployed
resources are matched with the deployable using the app.kubernetes.io/instance value

- [x] I wrote test cases to cover new code
