### PR TITLE
Fix regression for apps without matching subs

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,3 +106,4 @@ npm run test -- &lt;test_file&gt;
 # for example
 npm run test -- application.test.js
 </pre>
+

--- a/src/v2/models/application.js
+++ b/src/v2/models/application.js
@@ -685,7 +685,7 @@ export default class ApplicationModel extends GenericModel {
       // get subscriptions to channels (pipelines)
       let subscriptionNames = _.get(app, 'metadata.annotations["apps.open-cluster-management.io/subscriptions"]');
       let deployableNames = _.get(app, DEPLOYABLES);
-      if (evaluateSingleAnd(subscriptionNames, subscriptionNames.length > 0)) {
+      if (subscriptionNames && subscriptionNames.length > 0) {
         subscriptionNames = subscriptionNames.split(',');
         // filter local hub subscription
         const filteredSubscriptions = [];
@@ -729,7 +729,7 @@ export default class ApplicationModel extends GenericModel {
         if (includeChannels) {
           await this.getAppChannels(channelsMap);
         }
-      } else if (evaluateSingleAnd(deployableNames, deployableNames.length > 0)) {
+      } else if (deployableNames && deployableNames.length > 0) {
         deployableNames = deployableNames.split(',');
         model.deployables = await this.getApplicationResources(deployableNames, 'deployables', 'Deployable');
         await this.getPlacementRules(model.deployables);


### PR DESCRIPTION
**Related Issue:**
https://github.com/open-cluster-management/backlog/issues/10700

**Description of Changes**

Reverted a change for replacing && operators with a function. Now apps without matching subs will show up correctly displaying an error:

<img width="1623" alt="image" src="https://user-images.githubusercontent.com/38960034/111839902-e7986a00-88d1-11eb-8499-a45ffda84f16.png">
