### PR TITLE
allow processing object types on topo annotation

### DIFF
--- a/src/v2/schema/applicationHelper.js
+++ b/src/v2/schema/applicationHelper.js
@@ -193,8 +193,8 @@ export const getSubscriptionPackageInfo = (topoAnnotation, subscriptionName, app
       const deployableTypeLower = _.toLower(deployableData[2]);
 
       const isHook = isPrePostHookDeployable(subscription, dName, namespace);
-      // process only helm charts and hooks
-      if (deployableData[0] === 'helmchart' || isHook) {
+      // process only helm charts, object storage resources and hooks
+      if (deployableData[0] === 'helmchart' || deployableData[0] === 'object' || isHook) {
         if (!isHook) {
           dName = removeHelmReleaseName(deployableData[4], deployableData[1], packageName, aliasName);
           namespace = deployableData[3].length === 0 ? appNamespace : deployableData[3];


### PR DESCRIPTION
Signed-off-by: Valentina Birsan <vbirsan@redhat.com>

**Related Issue:** https://github.com/open-cluster-management/backlog/issues/12510

**Description of Changes**
Parse object storage resources on topo annotation using the **object** keyword

```
annotations:
    apps.open-cluster-management.io/topo: >-
      object//ConfigMap//game-demo/0,object//ConfigMap//game-demo-sub-01/0,object//ConfigMap//game-demo-sub-02/0
```
see https://github.com/open-cluster-management/backlog/issues/12510#issuecomment-840838415

- [ ] I wrote test cases to cover new code
