### PR TITLE
show deployables even when placement finds no cluster

### DIFF
--- a/src/v2/schema/applicationHelper.js
+++ b/src/v2/schema/applicationHelper.js
@@ -559,35 +559,34 @@ async function getApplicationElements(application, clusterModel, cluster) {
         hasPlacementRules = true;
       }
 
-      // add cluster(s) if any
-      if (isRulePlaced) {
-        // add cluster(s) if any or if too many
-        const clusterShapes = ruleClusterNames.length > 1
-          ? [ruleClusterNames] : ruleClusterNames.map((cn) => [cn]);
-        clusterShapes.forEach((names) => {
-          // add cluster element
-          clusterId = addClusters(
-            parentId, createdClusterElements, subscription,
-            names, clusters, links, nodes,
+      // add cluster(s)
+      // if no cluster found by the placement, use a default empty cluster name so that the deployables are parsed and shown
+      const clusterShapes = ruleClusterNames.length === 0 ? [['']] : ruleClusterNames.length > 1 ? [ruleClusterNames] 
+        : ruleClusterNames.map((cn) => [cn]);
+
+      clusterShapes.forEach((names) => {
+        // add cluster element
+        clusterId = addClusters(
+          parentId, createdClusterElements, subscription,
+          names, clusters, links, nodes,
+        );
+
+        if (subscription.deployables) {
+          // add deployables if any
+
+          processDeployables(
+            subscription.deployables,
+            clusterId, links, nodes, subscriptionStatusMap, names, namespace, subscription,
           );
+        }
 
-          if (subscription.deployables) {
-            // add deployables if any
-
-            processDeployables(
-              subscription.deployables,
-              clusterId, links, nodes, subscriptionStatusMap, names, namespace, subscription,
-            );
-          }
-
-          if (topoAnnotation) {
-            addSubscriptionCharts(
-              clusterId, subscriptionStatusMap, nodes,
-              links, names, namespace, subscriptionChannel, subscriptionName, topoAnnotation, subscription,
-            );
-          }
-        });
-      }
+        if (topoAnnotation) {
+          addSubscriptionCharts(
+            clusterId, subscriptionStatusMap, nodes,
+            links, names, namespace, subscriptionChannel, subscriptionName, topoAnnotation, subscription,
+          );
+        }
+      });
 
       // no deployables was placed on a cluster but there were subscription decisions
       if (!subscription.deployables && !hasPlacementRules && subscribeDecisions) {

--- a/src/v2/schema/applicationHelper.js
+++ b/src/v2/schema/applicationHelper.js
@@ -561,8 +561,12 @@ async function getApplicationElements(application, clusterModel, cluster) {
 
       // add cluster(s)
       // if no cluster found by the placement, use a default empty cluster name so that the deployables are parsed and shown
-      const clusterShapes = ruleClusterNames.length === 0 ? [['']] : ruleClusterNames.length > 1 ? [ruleClusterNames] 
-        : ruleClusterNames.map((cn) => [cn]);
+      let clusterShapes = [['']];
+      if (ruleClusterNames.length > 1) {
+        clusterShapes = [ruleClusterNames];
+      } else if (ruleClusterNames.length === 1) {
+        clusterShapes = ruleClusterNames.map((cn) => [cn]);
+      }
 
       clusterShapes.forEach((names) => {
         // add cluster element


### PR DESCRIPTION
**Description of Changes**

If no cluster matches the placement rule, the topology shows no deployables, just the subscription and rule node
We should show the deployable nodes in this case

- Without the fix

<img width="1173" alt="Screen Shot 2021-05-14 at 9 41 12 AM" src="https://user-images.githubusercontent.com/43010150/118283621-8dfd8780-b49d-11eb-95c8-59ac03f611bf.png">
<img width="858" alt="Screen Shot 2021-05-14 at 10 19 48 AM" src="https://user-images.githubusercontent.com/43010150/118284031-fea4a400-b49d-11eb-8b5e-e51cc2b12510.png">
<img width="1180" alt="Screen Shot 2021-05-14 at 10 20 01 AM" src="https://user-images.githubusercontent.com/43010150/118284034-ff3d3a80-b49d-11eb-9eaf-4eecb62e2f35.png">


- With the fix

<img width="879" alt="Screen Shot 2021-05-14 at 9 40 13 AM" src="https://user-images.githubusercontent.com/43010150/118283669-9c4ba380-b49d-11eb-876b-1448697e25e8.png">
<img width="797" alt="Screen Shot 2021-05-14 at 9 39 59 AM" src="https://user-images.githubusercontent.com/43010150/118283681-9fdf2a80-b49d-11eb-961c-0bd7d283f42a.png">
<img width="854" alt="Screen Shot 2021-05-14 at 9 40 23 AM" src="https://user-images.githubusercontent.com/43010150/118283697-a4a3de80-b49d-11eb-8dd1-f285c9a10e10.png">
<img width="908" alt="Screen Shot 2021-05-14 at 9 41 42 AM" src="https://user-images.githubusercontent.com/43010150/118283710-a8376580-b49d-11eb-88c3-fb6969682723.png">



- [ ] I wrote test cases to cover new code
