### PR TITLE
Update resourcetype definition for managedcluster action/views

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -10,3 +10,7 @@
 // Copyright Contributors to the Open Cluster Management project
 
 jest.setTimeout(30000);
+
+jest.mock('uuid', () => ({
+    v4: jest.fn(() => 1234),
+}));

--- a/src/v2/connectors/kube.js
+++ b/src/v2/connectors/kube.js
@@ -258,7 +258,7 @@ export default class KubeConnector {
   }
 
   // eslint-disable-next-line max-len
-  async managedClusterViewQuery(managedClusterNamespace, apiGroup, kind, resourceName, namespace, updateInterval, deleteAfterUse) {
+  async managedClusterViewQuery(managedClusterNamespace, apiGroup, version, kind, resourceName, namespace, updateInterval, deleteAfterUse) {
     // name cannot be long than 63 chars in length
     const name = crypto.createHash('sha1').update(`${managedClusterNamespace}-${resourceName}-${kind}`).digest('hex').substr(0, 63);
 
@@ -276,7 +276,7 @@ export default class KubeConnector {
       spec: {
         scope: {
           name: resourceName,
-          resource: `${kind}${apiGroup && `.${apiGroup}`}`,
+          resource: apiGroup ? `${kind.toLowerCase()}.${version}.${apiGroup}` : `${kind.toLowerCase()}`,
         },
       },
     };

--- a/src/v2/mocks/GenericResourceList.js
+++ b/src/v2/mocks/GenericResourceList.js
@@ -411,7 +411,21 @@ export const mockedUpdateWorkResponse = {
 export const mockedUpdatePollResponse = {
   body: {
     metadata: {
-      name: 'platform-auto-service-update-work-1234',
+      name: 'update-resource-1234',
+    },
+    status: {
+      result: {
+        apiVersion: 'v1',
+        kind: 'Secret',
+        metadata: {
+          creationTimestamp: '2019-04-16T01:40:57Z',
+          name: 'platform-auth-service',
+          namespace: 'kube-system',
+          resourceVersion: '6278503',
+          selfLink: '/api/v1/namespaces/kube-system/secret/platform-auth-service',
+          uid: 'ae97cf94-5fe8-11e9-bfe4-00000a150993',
+        },
+      },
     },
     items: [{
       status: {

--- a/src/v2/mocks/kube-http.js
+++ b/src/v2/mocks/kube-http.js
@@ -134,8 +134,6 @@ export default function createMockHttp() {
         return state.genericResourceList.getResourceMock;
       case params.url.includes('/api/v1/namespaces/klusterlet'):
         return state.genericResourceList.updateResourceLocalMock;
-      case params.url.includes('secrets/platform-auth-service'):
-        return state.genericResourceList.mockedUpdatePollResponse;
       case params.url.includes('/apis/project.openshift.io/v1/projects'):
         return state.project;
       case params.url.includes('layne-remote/managedclusteractions'):

--- a/src/v2/schema/__snapshots__/generic-resources.test.js.snap
+++ b/src/v2/schema/__snapshots__/generic-resources.test.js.snap
@@ -775,7 +775,18 @@ Object {
 exports[`Generic Resources Correctly Resolves Update Remote Resource 1`] = `
 Object {
   "data": Object {
-    "updateResource": "platform-auto-service-update-work-1234",
+    "updateResource": Object {
+      "apiVersion": "v1",
+      "kind": "Secret",
+      "metadata": Object {
+        "creationTimestamp": "2019-04-16T01:40:57Z",
+        "name": "platform-auth-service",
+        "namespace": "kube-system",
+        "resourceVersion": "6278503",
+        "selfLink": "/api/v1/namespaces/kube-system/secret/platform-auth-service",
+        "uid": "ae97cf94-5fe8-11e9-bfe4-00000a150993",
+      },
+    },
   },
 }
 `;

--- a/src/v2/schema/generic-resources.test.js
+++ b/src/v2/schema/generic-resources.test.js
@@ -45,7 +45,6 @@ describe('Generic Resources', () => {
   }));
 
   test('Correctly Resolves Update Remote Resource', () => new Promise((done) => {
-    Date.now = jest.fn(() => 1234);
     supertest(server)
       .post(GRAPHQL_PATH)
       .send({


### PR DESCRIPTION
Signed-off-by: Zack Layne <zlayne@redhat.com>

**Description of Changes**
- include the version and apiGroup in ManagedCluster action & view resources if available
- return the updated resource result in UpdateResource query
  - Fixes this issue after successful managed cluster resource update:
  
![Screen Shot 2021-06-21 at 3 04 01 PM](https://user-images.githubusercontent.com/14047925/122814306-feb87080-d2a1-11eb-947c-fb0b23d646ad.png)


- [x] I wrote test cases to cover new code
