### PR TITLE
Show error message when user tries to view a managed cluster secret

### DIFF
--- a/src/v2/models/generic.js
+++ b/src/v2/models/generic.js
@@ -233,6 +233,13 @@ export default class GenericModel extends KubeModel {
       });
     }
 
+    if (cluster !== 'local-cluster' && kind === 'secret') {
+      // We do not allow users to view secrets as this could allow lesser permissioned users to get around RBAC.
+      return [{
+        message: 'Viewing managed cluster secrets is not allowed for security reasons. To view this secret, you must access it from the specific managed cluster.',
+      }];
+    }
+
     // Check if the ManagedClusterView already exists if not create it
     const managedClusterViewName = crypto.createHash('sha1').update(`${cluster}-${name}-${kind}`).digest('hex').substr(0, 63);
 


### PR DESCRIPTION
Signed-off-by: Zack Layne <zlayne@redhat.com>

**Related Issue:** open-cluster-management/backlog#13702

**Description of Changes**
- Show an error message when users of any type try to view a managed cluster secret. `ManagedClusterView` resources do not allow secrets to be viewed.

<img width="1367" alt="Screen Shot 2021-06-25 at 2 17 14 PM" src="https://user-images.githubusercontent.com/14047925/123468655-0fc5f200-d5c0-11eb-9245-393c6e8cf795.png">
