### PR TITLE
fix managed cluster secret check

### DIFF
--- a/src/v2/models/generic.js
+++ b/src/v2/models/generic.js
@@ -233,7 +233,7 @@ export default class GenericModel extends KubeModel {
       });
     }
 
-    if (cluster !== 'local-cluster' && kind === 'secret') {
+    if (cluster !== 'local-cluster' && (kind.toLowerCase() === 'secret' || kind.toLowerCase() === 'secrets')) {
       // We do not allow users to view secrets as this could allow lesser permissioned users to get around RBAC.
       return [{
         message: 'Viewing managed cluster secrets is not allowed for security reasons. To view this secret, you must access it from the specific managed cluster.',


### PR DESCRIPTION
Signed-off-by: Zack Layne <zlayne@redhat.com>

**Related Issue:** [closes|resolves|fixes] open-cluster-management/backlog#13702

**Description of Changes**
- added to check for plural kind strings - previously was only checking for singular.
