### PR TITLE
Add api for querying appset data

### DIFF
--- a/src/v2/mocks/AppList.js
+++ b/src/v2/mocks/AppList.js
@@ -1180,3 +1180,136 @@ export const mockDeleteAppResponse = {
     },
   },
 };
+
+export const mockGitopsclusterDefaultResponse = {
+  body: {
+    kind: 'GitopsclusterList',
+    apiVersion: 'apps.open-cluster-management.io/v1alpha1',
+    metadata: {
+      selfLink: '/apis/apps.open-cluster-management.io/v1alpha1/namespaces/default/gitopsclusters',
+      resourceVersion: '76724277',
+    },
+    items: [
+      {
+        metadata: {
+          name: 'argo-acm-clusters-1',
+          namespace: 'default',
+          selfLink: '/apis/apps.open-cluster-management.io/v1alpha1/namespaces/default/gitopsclusters/argo-acm-clusters-1',
+          uid: 'f701351d-c2d7-452b-9fae-3263ee28a26f',
+          resourceVersion: '281',
+          creationTimestamp: '2018-11-12T18:48:14Z',
+        },
+        spec: {
+          argoServer: {
+            argoNamespace: 'default',
+            cluster: 'josh',
+          },
+          placementRef: {
+            apiVersion: 'cluster.open-cluster-management.io/v1alpha1',
+            kind: 'Placement',
+            name: 'local-cluster',
+            namespace: 'default',
+          },
+        },
+        status: {},
+      },
+    ],
+  },
+};
+
+export const mockGitopsclusterKubeSystemResponse = {
+  body: {
+    kind: 'GitopsclusterList',
+    apiVersion: 'apps.open-cluster-management.io/v1alpha1',
+    metadata: {
+      selfLink: '/apis/apps.open-cluster-management.io/v1alpha1/namespaces/kube-system/gitopsclusters',
+      resourceVersion: '76724277',
+    },
+    items: [
+      {
+        metadata: {
+          name: 'argo-acm-clusters-1',
+          namespace: 'kube-system',
+          selfLink: '/apis/apps.open-cluster-management.io/v1alpha1/namespaces/kube-system/gitopsclusters/argo-acm-clusters-1',
+          uid: 'f701351d-c2d7-452b-9fae-3263ee28a26f',
+          resourceVersion: '281',
+          creationTimestamp: '2018-11-12T18:48:14Z',
+        },
+        spec: {
+          argoServer: {
+            argoNamespace: 'kube-system',
+            cluster: 'josh',
+          },
+          placementRef: {
+            apiVersion: 'cluster.open-cluster-management.io/v1alpha1',
+            kind: 'Placement',
+            name: 'local-cluster',
+            namespace: 'kube-system',
+          },
+        },
+        status: {},
+      },
+    ],
+  },
+};
+
+export const mockAppsetResponse = {
+  body: {
+    kind: 'ApplicationSetList',
+    apiVersion: 'argoproj.io/v1alpha1',
+    metadata: {
+      selfLink: '/apis/argoproj.io/v1alpha1/namespaces/kube-system/applicationsets',
+      resourceVersion: '76724277',
+    },
+    items: [
+      {
+        metadata: {
+          name: 'argo-appset-1',
+          namespace: 'kube-system',
+          selfLink: '/apis/argoproj.io/v1alpha1/namespaces/kube-system/applicationsets/argo-appset-1',
+          uid: 'f701351d-c2d7-452b-9fae-3263ee28a26a',
+          resourceVersion: '282',
+          creationTimestamp: '2018-11-12T18:48:14Z',
+        },
+        spec: {
+          generators: [
+            {
+              clusterDecisionResource: {
+                configMapRef: 'acm-placement',
+                labelSelector: {
+                  matchLabels: {
+                    'cluster.open-cluster-management.io/placement': 'test-placement',
+                  },
+                },
+                requeueAfterSeconds: 180,
+              },
+            },
+          ],
+          template: {
+            metadata: {
+              name: 'argo-appset-1-{{name}}',
+            },
+            spec: {
+              destination: {
+                namespace: 'argo-appset-ns',
+                server: '{{server}}',
+              },
+              project: 'default',
+              source: {
+                path: 'helloworld',
+                repoURL: 'https://github.com/fxiang1/app-samples.git',
+                targetRevision: 'main',
+              },
+              syncPolicy: {
+                syncOptions: [
+                  'CreateNamespace=true',
+                ],
+              },
+            },
+          },
+        },
+        status: {},
+      },
+    ],
+  },
+};

--- a/src/v2/mocks/kube-http.js
+++ b/src/v2/mocks/kube-http.js
@@ -60,6 +60,12 @@ export default function createMockHttp() {
       }
     }
     switch (true) {
+      case params.url.includes('apps.open-cluster-management.io/v1alpha1/namespaces/kube-system/gitopsclusters'):
+        return state.apps.mockGitopsclusterKubeSystemResponse;
+      case params.url.includes('apps.open-cluster-management.io/v1alpha1/namespaces/default/gitopsclusters'):
+        return state.apps.mockGitopsclusterDefaultResponse;
+      case params.url.includes('argoproj.io/v1alpha1/namespaces/kube-system/applicationsets'):
+        return state.apps.mockAppsetResponse;
       case params.url.endsWith('/api/v1'):
         return state.apiList.apiPath;
       case params.url.endsWith('/apis/cluster.open-cluster-management.io/v1'):

--- a/src/v2/schema/__snapshots__/application.test.js.snap
+++ b/src/v2/schema/__snapshots__/application.test.js.snap
@@ -277,3 +277,18 @@ Object {
   ],
 }
 `;
+
+exports[`Appset related resources Resolver Correctly Resolves Appset related resources Query 1`] = `
+Object {
+  "data": Object {
+    "applicationSetRelatedResources": Object {
+      "appSetBeingDeleted": Object {
+        "name": "argo-appset-1",
+        "namespace": "kube-system",
+      },
+      "appSetPlacement": "test-placement",
+      "appSetsSharingPlacement": Array [],
+    },
+  },
+}
+`;

--- a/src/v2/schema/application.js
+++ b/src/v2/schema/application.js
@@ -71,6 +71,7 @@ export const resolver = {
   Query: {
     application: (root, args, { applicationModel }) => applicationModel.getApplication(args.name, args.namespace, ALL_SUBSCRIPTIONS, true, undefined, args.apiversion),
     applications: (root, args, { applicationModel }) => applicationModel.getApplications(),
+    applicationSetRelatedResources: (root, args, { applicationModel }) => applicationModel.getApplicationSetRelatedResources(args.name, args.namespace),
     applicationNamespaces: (parent, args, { applicationModel }) => applicationModel.getApplicationNamespace(args.namespace),
     secrets: (root, args, { applicationModel }) => applicationModel.getSecrets(args),
     argoServers: (root, args, { applicationModel }) => applicationModel.getArgoServerNs(),

--- a/src/v2/schema/application.test.js
+++ b/src/v2/schema/application.test.js
@@ -160,3 +160,21 @@ describe('Application Resolver', () => {
       });
   }));
 });
+
+describe('Appset related resources Resolver', () => {
+  test('Correctly Resolves Appset related resources Query', () => new Promise((done) => {
+    supertest(server)
+      .post(GRAPHQL_PATH)
+      .send({
+        query: `
+          {
+            applicationSetRelatedResources(name:"argo-appset-1", namespace:"kube-system")
+          }
+      `,
+      })
+      .end((err, res) => {
+        expect(JSON.parse(res.text)).toMatchSnapshot();
+        done();
+      });
+  }));
+});

--- a/src/v2/schema/query.js
+++ b/src/v2/schema/query.js
@@ -21,6 +21,9 @@ type Query {
   # Get basic list of all applications (including Argo)
   applications(name: String, namespace: String): [BasicApplication]
 
+  # Get list of applicationsets
+  applicationSetRelatedResources(name: String, namespace: String): JSON
+
   # Get ArgoApp Route URL
   argoAppRouteURL(cluster: String!, namespace: String!, name: String!, apiVersion: String!): String
 


### PR DESCRIPTION
Signed-off-by: Feng Xiang <fxiang@redhat.com>

**Related Issue:** https://github.com/open-cluster-management/backlog/issues/14872

**Description of Changes**

- Add api for querying appset relate resources data

sample query:
```
query applicationSetRelatedResources($name: String, $namespace: String) {
  applicationSetRelatedResources(name: $name, namespace: $namespace)
}

{
  "name": "argo-appset-1",
  "namespace": "openshift-gitops"
}
```
- [x] I wrote test cases to cover new code
