### PR TITLE
Don't process deployables for objectstore apps

### DIFF
--- a/src/v2/schema/applicationHelper.js
+++ b/src/v2/schema/applicationHelper.js
@@ -513,6 +513,7 @@ async function getApplicationElements(application, clusterModel, cluster) {
       const subscriptionChannel = _.get(subscription, 'spec.channel');
       const subscriptionName = _.get(subscription, metadataName, '');
       const topoAnnotation = _.get(subscription, 'metadata.annotations', {})['apps.open-cluster-management.io/topo'];
+      const isObjectApp = topoAnnotation ? _.startsWith(topoAnnotation, 'object//') : false;
       // get cluster placement if any
       const ruleDecisionMap = {};
       if (subscription.rules) {
@@ -575,7 +576,7 @@ async function getApplicationElements(application, clusterModel, cluster) {
           names, clusters, links, nodes,
         );
 
-        if (subscription.deployables) {
+        if (subscription.deployables && !isObjectApp) {
           // add deployables if any
 
           processDeployables(


### PR DESCRIPTION
Signed-off-by: Feng Xiang <fxiang@redhat.com>

**Related Issue:** https://github.com/open-cluster-management/backlog/issues/15765

**Description of Changes**

- Prevent the processing of subscription deployables for objectstore apps

The app now displays correctly in the topology:
<img width="1026" alt="image" src="https://user-images.githubusercontent.com/38960034/131888945-1572f6c3-1db2-4116-a8d1-16bdc3514fff.png">

