### PR TITLE
[release-2.3] Exclude detached clusters from overview query

### DIFF
--- a/src/v2/models/cluster.js
+++ b/src/v2/models/cluster.js
@@ -121,7 +121,6 @@ function mapData({
 
   const uniqueClusterNames = new Set([
     ...managedClusterMap.keys(),
-    ...clusterDeploymentMap.keys(),
   ]);
 
   return {


### PR DESCRIPTION
Signed-off-by: Kevin Cormier <kcormier@redhat.com>

**Related Issue:** related to open-cluster-management/backlog#16135

**Description of Changes**

- Exclude ClusterDeployments without ManagedClusters (detached) from Overview query

