### PR TITLE
Set apiVersion to unknown to indicate we need to look for the search …

### DIFF
--- a/src/v2/schema/applicationHelper.js
+++ b/src/v2/schema/applicationHelper.js
@@ -212,7 +212,7 @@ export const getSubscriptionPackageInfo = (topoAnnotation, subscriptionName, app
           },
           spec: {
             template: {
-              apiVersion: 'apps/v1',
+              apiVersion: 'unknown',
               kind: deployableData[2],
               metadata: {
                 namespace,


### PR DESCRIPTION
Signed-off-by: Feng Xiang <fxiang@redhat.com>

**Related Issue:** https://github.com/open-cluster-management/backlog/issues/16644

**Description of Changes**

Currently for Helm/Object store apps we don't have the apiVersion data because the app backend doesn't generate the deployables data for these so instead of using an arbitrary value `apps/v1`, I'm setting the apiVersion to `unknown` to indicate in App UI we need lookup the apiVersion from search instead.
